### PR TITLE
add dplyr tutorial to Getting and Cleaning Data

### DIFF
--- a/getclean.md
+++ b/getclean.md
@@ -6,3 +6,4 @@ permalink: /getclean/
 
 - [Subsetting example walkthrough](http://rpubs.com/thoughtfulbloke/subset)
 - [Apples to Oranges Data Organisation Challenge](https://github.com/thoughtfulbloke/faoexample)
+- [dplyr Video Tutorial](https://www.youtube.com/watch?v=jWjqLW-u3hc) and [R Markdown document](http://rpubs.com/justmarkham/dplyr-tutorial): An [update](http://blog.rstudio.org/2014/01/17/introducing-dplyr/) to the plyr package, useful for subsetting, sorting, summarizing, and merging data using a more intuitive syntax than plyr or base R.


### PR DESCRIPTION
My pull request is for an additional link to the Getting and Cleaning Data page. I created a 40-minute video tutorial (and a related R Markdown document) that teaches the fundamentals of the dplyr package in R.

As for the questions:
1. Does my contribution teach? Yes, I actually taught this exact material to a real-life data science class.
2. Does the content of my contribution clearly address topics in the Data Science Specialization? Yes, dplyr is directly relevant for week 3 of Getting and Cleaning Data.
3. Could my contribution be seamlessly integrated into the canonical course materials? Yes, you could teach almost all of week 3 using dplyr instead of using plyr and base R. And in fact, I bet the instructor would have used dplyr for week 3 had it existed at the time the videos were recorded! (dplyr was launched in January 2014).

Thanks! I'm happy to answer any questions and/or revise the text if desired.
