### PR TITLE
Added a link to Rmdformat

### DIFF
--- a/repres.md
+++ b/repres.md
@@ -6,4 +6,5 @@ permalink: /repres/
 
 - [Turning a RPubs document into a Github website walkthrough](https://github.com/thoughtfulbloke/appleorange)
 - [Introduction to knitr with rmarkdown](https://sachsmc.github.io/knit-git-markr-guide/knitr/knit.html)
+- [Rmdformat: Simple script to convert Rmd files to other formats](https://github.com/rocher/bretools/blob/master/Rmdformat)
 


### PR DESCRIPTION
I've created an Rscript to convert Rmd files to other formats (md, html, odt, pdf) from the command line. Tested and verified under Linux, should work fine in OSX too.
