### PR TITLE
add links to ISLR videos

### DIFF
--- a/pml.md
+++ b/pml.md
@@ -7,3 +7,7 @@ permalink: /pml/
 ## Model Evaluation
 
 - [Simple Guide to Confusion Matrix Terminology (sensitivity, specificity, etc.)](http://www.dataschool.io/simple-guide-to-confusion-matrix-terminology/)
+
+## Supplementary Videos
+
+- [Video lectures from "An Introduction to Statistical Learning"](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/): Videos for Chapters 4, 5, 6, 8, and 10 can help to deepen your understanding of the topics presented in this course.

--- a/regmod.md
+++ b/regmod.md
@@ -4,3 +4,6 @@ title: Regression Models
 permalink: /regmod/
 ---
 
+## Supplementary Videos
+
+- [Video lectures from "An Introduction to Statistical Learning"](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/): Videos for Chapter 3 can help to deepen your understanding of regression.


### PR DESCRIPTION
Hello! I have a blog post linking to all of the lecture videos from "An Introduction to Statistical Learning", which is an excellent textbook by Hastie and Tibshirani that Dr. Leek recommends. The videos are very relevant to Regression Models and Practical Machine Learning.

While this is not "my work" in the sense that I didn't create the videos, it is "my work" in the sense that I gathered all the links to the slides and the videos (which are unlisted on YouTube), came up with a descriptive title for each video, created playlists for each chapter, and obviously wrote the blog post. That being said, I'm happy to move this to Curated Knowledge if you think it belongs there instead!
