### PR TITLE
add link to Kaggle blog post on Practical Machine Learning page

### DIFF
--- a/pml.md
+++ b/pml.md
@@ -11,3 +11,7 @@ permalink: /pml/
 ## Supplementary Videos
 
 - [Video lectures from "An Introduction to Statistical Learning"](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/): Videos for Chapters 4, 5, 6, 8, and 10 can help to deepen your understanding of the topics presented in this course.
+
+## Machine Learning Competitions
+
+- [Participating in Kaggle's Allstate Purchase Prediction Challenge](http://www.dataschool.io/kaggle-allstate-purchase-prediction-challenge/): Description of what it's like to compete in a Kaggle competition, including links to a project paper, R code, presentation slides, and a presentation video.


### PR DESCRIPTION
Hello!

I thought this post might be of interest to many students in the Machine Learning course. The blog post gives an overview of what it was like to participate in a Kaggle competition as a novice, and I link to my project paper which I think is very instructive (in terms of showing students some strategies for approaching a machine learning problem). I include my R code, as well as presentation slides and a video (for students who prefer to absorb the material in that way).

Thanks,
Kevin
