### PR TITLE
RPub NOAA Data

### DIFF
--- a/repres.md
+++ b/repres.md
@@ -7,7 +7,8 @@ permalink: /repres/
 - [Turning a RPubs document into a Github website walkthrough](https://github.com/thoughtfulbloke/appleorange)
 - [Introduction to knitr with rmarkdown](https://sachsmc.github.io/knit-git-markr-guide/knitr/knit.html)
 - [Trends and severity of Data Breaches](http://rpubs.com/ww44ss/29389)
-- [Benefit-cost analysis of a park user fee](https://rstudio-pubs-static.s3.amazonaws.com/72135_dc45211d976842c2a9a8c8b5f2472ff0.html) 
+- [Benefit-cost analysis of a park user fee](https://rstudio-pubs-static.s3.amazonaws.com/72135_dc45211d976842c2a9a8c8b5f2472ff0.html)
+- [Data Lake Integrity](http://rpubs.com/rshane/81297)
 
 ## Comprehensive Notes
 


### PR DESCRIPTION
The repres.md file was updated with a link to an RPub I posted that uses current NOAA data and goes through a rigorous exercise of enforcing data integrity. Also, incorporates the use of an Oracle database which might be interesting for those interested in pushing and getting data from a database - more generic RJDBC package used as opposed to one for a specific database.  