### PR TITLE
Remove advert from Other Resources page

### DIFF
--- a/other.md
+++ b/other.md
@@ -22,8 +22,6 @@ permalink: /other/
 ## Pre-built virtual machines for R development.
 - [Here's a pre-built lightweight Linux machine with R and RStudio already installed](https://github.com/queirozfcom/r-box). You just need to install [vagrant](https://www.vagrantup.com/downloads.html), download (or clone) the github repository and you'll get a clean ubuntu machine with the tools you'll need for the assignments. 
 
-- [Data Science Appliance](http://datascienceappliance.com/) - A perfectly provisioned virtual machine for data scientists.
-
 - [Data Science Toolbox](http://datasciencetoolbox.org/) - A virtual environment that allows you to start doing data science in a matter of minutes.
 
 - [Virtual machine with RStudio server and github setup](https://github.com/tboloo/vagrant-rstudio) - A VirtualBox, Vagrant & chef-solo managed virtual machine which provides RStudio server with git & github setup


### PR DESCRIPTION
Data Science Appliance is an add website; it redirects through doubleclick.net. 