### PR TITLE
Added link to 'real world example' reading ACS 2000 PUMS data.

### DIFF
--- a/getclean.md
+++ b/getclean.md
@@ -14,6 +14,7 @@ permalink: /getclean/
 - [Query string (and other fields-within-fields) unrolling](http://rpubs.com/schnee/32988)
 - [Pre-processing Excel files before loading them into R](https://github.com/alkashef/cleaningexceldata)
 - [Codebook template that can be used in the Getting and Cleaning Data project](https://gist.github.com/JorisSchut/dbc1fc0402f28cad9b41)
+- ["Real world" example - reading American Community Survey 2000 PUMS Data:](https://github.com/lgreski/acsexample) Demonstrates how to extract records of a given type from a data file containing multiple record types, and how to use an Excel-based code book to specify arguments for reading a fixed-width file.
 
 ## Comprehensive Notes
 


### PR DESCRIPTION
In response to a student question about reading the 2000 American Community Survey Public Use Microdata Sample, we developed a solution that combined three techniques from the Getting and Cleaning Data course. The code and associated README are referenced in my update to the getclean.md file. 